### PR TITLE
reexport NewHTTPClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,6 +25,12 @@ func New(keyname string) (*Client, error) {
 	}, nil
 }
 
+// NewHTTPClient returns a new bare HTTP API client.
+// Most users will call New() instead.
+func NewHTTPClient(formats strfmt.Registry) *client.TurnkeyPublicAPI {
+	return client.NewHTTPClient(formats)
+}
+
 // Client provides a handle by which to interact with the Turnkey API.
 type Client struct {
 	client *client.TurnkeyPublicAPI


### PR DESCRIPTION
Because the api/client directory and the base client directory share the same name, it is unpleasant to have to import both into downstream codebases.

This simply wraps the former into the latter so that users of the SDK need only import the base package.