### PR TITLE
Update macOS default keys dir

### DIFF
--- a/pkg/store/local/local.go
+++ b/pkg/store/local/local.go
@@ -73,28 +73,33 @@ func (s *Store) MetadataFile(name string) string {
 func DefaultKeysDir() string {
 	var cfgDir string
 
+	shouldUseHomeDir := false
+
 	// The default `UserConfigDir` in golang doesn't make sense on macOS
 	// https://github.com/golang/go/issues/29960#issuecomment-505321146
 	// Solution: always use `~/.config/turkey` on macOS when possible
 	if runtime.GOOS == "darwin" {
-		homeDir, err := os.UserHomeDir()
+		if os.Getenv("XDG_CONFIG_HOME") != "" {
+			cfgDir = os.Getenv("XDG_CONFIG_HOME")
+		} else {
+			shouldUseHomeDir = true
+		}
+	} else {
+		var err error
 
+		cfgDir, err = os.UserConfigDir()
+
+		if err != nil {
+			shouldUseHomeDir = true
+		}
+	}
+
+	if shouldUseHomeDir {
+		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			cfgDir = "."
 		} else {
 			cfgDir = path.Join(homeDir, ".config")
-		}
-	} else {
-		var err error
-		cfgDir, err = os.UserConfigDir()
-
-		if err != nil {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				cfgDir = "."
-			} else {
-				cfgDir = path.Join(homeDir, ".config")
-			}
 		}
 	}
 

--- a/pkg/store/local/local_test.go
+++ b/pkg/store/local/local_test.go
@@ -2,6 +2,7 @@ package local_test
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,10 @@ func TestGetKeyDirPathMacOSX(t *testing.T) {
 // On UNIX, we expect XDG_CONFIG_HOME to be set.
 // If it's not set, we're back to a MacOSX-like system.
 func TestGetKeyDirPathUnix(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping on macOS (default path is `~/.config/turkey` unless you specify an override via the CLI)")
+	}
+
 	assert.Nil(t, os.Setenv("XDG_CONFIG_HOME", "/special/dir"))
 
 	defer func() {

--- a/pkg/store/local/local_test.go
+++ b/pkg/store/local/local_test.go
@@ -2,7 +2,6 @@ package local_test
 
 import (
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,10 +33,6 @@ func TestGetKeyDirPathMacOSX(t *testing.T) {
 // On UNIX, we expect XDG_CONFIG_HOME to be set.
 // If it's not set, we're back to a MacOSX-like system.
 func TestGetKeyDirPathUnix(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("Skipping on macOS (default path is `~/.config/turkey` unless you specify an override via the CLI)")
-	}
-
 	assert.Nil(t, os.Setenv("XDG_CONFIG_HOME", "/special/dir"))
 
 	defer func() {


### PR DESCRIPTION
## Summary
See inline comments; the default `UserConfigDir` in golang doesn't make sense on macOS

https://github.com/tkhq/tkcli/issues/34

## Test Plan
CI