### PR TITLE
[easy] Fix legacy dir error checking

### DIFF
--- a/pkg/store/local/local.go
+++ b/pkg/store/local/local.go
@@ -78,7 +78,7 @@ func DeprecatedDefaultKeysDir() string {
 	}
 
 	cfgDir, err := os.UserConfigDir()
-	if err == nil {
+	if err != nil {
 		return ""
 	}
 


### PR DESCRIPTION
## Summary
Somehow missed this in https://github.com/tkhq/go-sdk/pull/10

## Test Plan
Ran it via a local CLI build