### PR TITLE
Fixes imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ import (
 	"fmt"
 
 	"github.com/tkhq/go-sdk"
-	"github.com/tkhq/go-sdk/pkg/users"
-	"github.com/tkhq/go-sdk/pkg/models"
+	"github.com/tkhq/go-sdk/pkg/api/client/users"
+	"github.com/tkhq/go-sdk/pkg/api/models"
 )
 
 func ExampleClient() {


### PR DESCRIPTION
in go 1.20.3 on mac/ m2 
```
github.com/tkhq/go-sdk/pkg/models: module github.com/tkhq/go-sdk@latest found (v0.0.0-20230523203708-7c199d0f6909), but does not contain package github.com/tkhq/go-sdk/pkg/models
noki/lib/nodes imports
	github.com/tkhq/go-sdk/pkg/users: module github.com/tkhq/go-sdk@latest found (v0.0.0-20230523203708-7c199d0f6909), but does not contain package github.com/tkhq/go-sdk/pkg/users
```

It seems the Users and Models changed locations without the readme being updated. This import path works for me and I'm able to compile and use the sdk