### PR TITLE
add ID field to api key metadata

### DIFF
--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -17,9 +17,16 @@ import (
 
 // Metadata stores non-secret metadata about the API key.
 type Metadata struct {
-	Name          string   `json:"name"`
+	// ID is the unique identifier of the API key inside the Turnkey database.
+	ID string `json:"id"`
+
+	// Name is the arbitrary human-readable label of this key.
+	Name string `json:"name"`
+
+	// Organizations is the set of organizations to which this API key is bound and for which this API key can enact API calls.
 	Organizations []string `json:"organizations"`
 
+	// PublicKey is the text form of the PublicKey, for display purposes.
 	PublicKey string `json:"public_key"`
 }
 
@@ -41,6 +48,7 @@ func (k *Key) MergeMetadata(md *Metadata) error {
 		return errors.Errorf("metadata public key %q does not match API key public key %q", md.PublicKey, k.TkPublicKey)
 	}
 
+	k.Metadata.ID = md.ID
 	k.Metadata.Name = md.Name
 	k.Metadata.Organizations = md.Organizations
 	k.Metadata.PublicKey = md.PublicKey

--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -23,11 +23,14 @@ type Metadata struct {
 	// Name is the arbitrary human-readable label of this key.
 	Name string `json:"name"`
 
-	// Organizations is the set of organizations to which this API key is bound and for which this API key can enact API calls.
+	// Organizations is the set unique identifiers of organizations to which this API key is bound and for which this API key can enact API calls.
 	Organizations []string `json:"organizations"`
 
 	// PublicKey is the text form of the PublicKey, for display purposes.
 	PublicKey string `json:"public_key"`
+
+	// User is the unique identifier of the user to which this API key is attached and on behalf of whom activities by this key will be taken.
+	User string `json:"user"`
 }
 
 // Key defines a structure in which to hold both serialized and ecdsa-lib-friendly versions of a Turnkey API keypair.
@@ -52,6 +55,7 @@ func (k *Key) MergeMetadata(md *Metadata) error {
 	k.Metadata.Name = md.Name
 	k.Metadata.Organizations = md.Organizations
 	k.Metadata.PublicKey = md.PublicKey
+	k.Metadata.User = md.User
 
 	return nil
 }


### PR DESCRIPTION
In order to manipulate API keys in the API, we actually need the apikey's ID.
This adds the field to the apikey metadata so that it can be used later.