### PR TITLE
Make the sdk compatible with a custom keystore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import (
 
 func main() {
 	// NB: make sure to create and register an API key, first.
-	client, err := sdk.New("") // your local API key name
+	client, err := sdk.New("", nil) // your local API key name
 	if err != nil {
 		log.Fatal("failed to create new SDK client:", err)
 	}

--- a/client.go
+++ b/client.go
@@ -11,9 +11,12 @@ import (
 	"github.com/tkhq/go-sdk/pkg/store"
 )
 
-// New returns a new API Client with the given API key name from the default keystore.
-func New(keyname string) (*Client, error) {
-	apiKey, err := store.Default.Load(keyname)
+// New returns a new API Client with the given API key name from the given keystore. When nil, "keystore" reverts to store.Default
+func New(keyname string, keystore store.Store) (*Client, error) {
+	if keystore == nil {
+		keystore = store.Default
+	}
+	apiKey, err := keystore.Load(keyname)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load API key")
 	}

--- a/examples/privatekeys/signTransaction.go
+++ b/examples/privatekeys/signTransaction.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	// NB: make sure to create and register an API key, first.
-	client, err := sdk.New("default")
+	client, err := sdk.New("default", nil)
 	if err != nil {
 		log.Fatal("failed to create new SDK client:", err)
 	}

--- a/examples/whoami/whoami.go
+++ b/examples/whoami/whoami.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	// NB: make sure to create and register an API key, first.
-	client, err := sdk.New("")
+	client, err := sdk.New("", nil)
 	if err != nil {
 		log.Fatal("failed to create new SDK client:", err)
 	}


### PR DESCRIPTION
The method sdk.New takes in only the keyname, while the sdk already supports a custom store by implementing the store.Store interface, it is currently not possible to use this custom store.

This PR makes this possible by passing in a store.Store type into sdk.New. 