### PR TITLE
add ramstore for testing

### DIFF
--- a/pkg/store/ram/store.go
+++ b/pkg/store/ram/store.go
@@ -1,0 +1,49 @@
+// Package ram defines a RAM-based apikey store.
+// It is recommended this only be used for testing, because NOTHING IS PERSISTED TO DISK!
+package ram
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/tkhq/go-sdk/pkg/apikey"
+)
+
+// Store implements a VOLATILE RAM-based keystore.
+// This should only be used for testing.
+type Store struct {
+	s map[string]*apikey.Key
+
+	mu sync.Mutex
+}
+
+// Load implements store.Store.
+func (s *Store) Load(name string) (*apikey.Key, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.s == nil {
+		return nil, errors.New("key not found")
+	}
+
+	key, ok := s.s[name]
+	if !ok {
+		return nil, errors.New("key not found")
+	}
+
+	return key, nil
+}
+
+// Store implements store.Store.
+func (s *Store) Store(name string, key *apikey.Key) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.s == nil {
+		s.s = make(map[string]*apikey.Key)
+	}
+
+	s.s[name] = key
+
+	return nil
+}

--- a/pkg/store/ram/store_test.go
+++ b/pkg/store/ram/store_test.go
@@ -1,0 +1,26 @@
+package ram_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tkhq/go-sdk/pkg/apikey"
+	"github.com/tkhq/go-sdk/pkg/store/ram"
+)
+
+func TestStore(t *testing.T) {
+	s := new(ram.Store)
+
+	key, err := apikey.New("2a7e29e2-9e92-48c2-98bf-c849c1159bc7")
+	assert.Nil(t, err)
+	assert.NotNil(t, key)
+
+	assert.Nil(t, s.Store("test", key))
+
+	retrievedKey, err := s.Load("test")
+	assert.Nil(t, err)
+	assert.Equal(t, key.Name, retrievedKey.Name)
+	assert.Equal(t, key.Organizations[0], retrievedKey.Organizations[0])
+	assert.Equal(t, key.PublicKey, retrievedKey.PublicKey)
+}


### PR DESCRIPTION
Adds a RAM-based store to allow for downstream tool testing.