### PR TITLE
Update `pkg/enclave_encrypt` to support `v1.0.0` import/export bundles

### DIFF
--- a/pkg/enclave_encrypt/encrypt.go
+++ b/pkg/enclave_encrypt/encrypt.go
@@ -206,12 +206,12 @@ func decrypt(
 
 	receiver, err := suite.NewReceiver(receiverPrivate, []byte(TurnkeyHpkeInfo))
 	if err != nil {
-		return nil, fmt.Errorf("bad receiver private key")
+		return nil, fmt.Errorf("bad receiver private key: %s", err.Error())
 	}
 
 	opener, err := receiver.Setup(encappedPublic)
 	if err != nil {
-		return nil, fmt.Errorf("bad encapsulated public key")
+		return nil, fmt.Errorf("bad encapsulated public key: %s", err.Error())
 	}
 
 	aad, err := additionalAssociatedData(receiverPrivate.Public(), encappedPublic)

--- a/pkg/enclave_encrypt/encrypt.go
+++ b/pkg/enclave_encrypt/encrypt.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/cloudflare/circl/hpke"
@@ -67,8 +68,8 @@ type ServerSendMsgV0 struct {
 type ServerSendMsgV1 struct {
 	// Version of the data.
 	Version string `json:"version"`
-	// Data sent by the enclave.
-	Data ServerSendData `json:"data"`
+	// Data sent by the enclave
+	Data Bytes `json:"data"`
 	// Enclave quorum key signature over the data.
 	DataSignature Bytes `json:"dataSignature"`
 	// Enclave quorum key public key.
@@ -95,13 +96,13 @@ type ServerTargetMsgV0 struct {
 	TargetPublicSignature Bytes `json:"targetPublicSignature"`
 }
 
-// / Message from the server with data, the data's version, enclave quorum key, and the enclave
-// / quorum key signature over the data.
+// Message from the server with data, the data's version, enclave quorum key, and the enclave
+// quorum key signature over the data.
 type ServerTargetMsgV1 struct {
 	// Version of the data.
 	Version string `json:"version"`
-	// Data sent by the enclave.
-	Data ServerTargetData `json:"data"`
+	// Data sent and signed by the enclave.
+	Data Bytes `json:"data"`
 	// Enclave quorum key signature over the data.
 	DataSignature Bytes `json:"dataSignature"`
 	// Enclave quorum key public key.
@@ -205,12 +206,12 @@ func decrypt(
 
 	receiver, err := suite.NewReceiver(receiverPrivate, []byte(TurnkeyHpkeInfo))
 	if err != nil {
-		return []byte{}, nil
+		return nil, fmt.Errorf("bad receiver private key")
 	}
 
 	opener, err := receiver.Setup(encappedPublic)
 	if err != nil {
-		return []byte{}, nil
+		return nil, fmt.Errorf("bad encapsulated public key")
 	}
 
 	aad, err := additionalAssociatedData(receiverPrivate.Public(), encappedPublic)

--- a/pkg/enclave_encrypt/go.mod
+++ b/pkg/enclave_encrypt/go.mod
@@ -1,6 +1,6 @@
 module github.com/tkhq/go-sdk/pkg/enclave_encrypt
 
-go 1.21
+go 1.19
 
 require (
 	github.com/cloudflare/circl v1.3.7

--- a/pkg/enclave_encrypt/go.mod
+++ b/pkg/enclave_encrypt/go.mod
@@ -1,6 +1,6 @@
 module github.com/tkhq/go-sdk/pkg/enclave_encrypt
 
-go 1.19
+go 1.21
 
 require (
 	github.com/cloudflare/circl v1.3.7

--- a/pkg/enclave_encrypt/server.go
+++ b/pkg/enclave_encrypt/server.go
@@ -87,7 +87,7 @@ func (s *EnclaveEncryptServer) Encrypt(clientTarget []byte, plaintext []byte) (*
 
 	return &ServerSendMsgV1{
 		Version:             DataVersion,
-		Data:                data,
+		Data:                dataBytes,
 		DataSignature:       dataSig,
 		EnclaveQuorumPublic: eqp,
 	}, nil
@@ -127,7 +127,7 @@ func (s *EnclaveEncryptServer) PublishTarget() (*ServerTargetMsgV1, error) {
 
 	return &ServerTargetMsgV1{
 		Version:             DataVersion,
-		Data:                data,
+		Data:                dataBytes,
 		DataSignature:       dataSig,
 		EnclaveQuorumPublic: eqp,
 	}, nil

--- a/pkg/enclave_encrypt/server.go
+++ b/pkg/enclave_encrypt/server.go
@@ -11,6 +11,7 @@ import (
 
 type EnclaveEncryptServer struct {
 	enclaveAuthKey *ecdsa.PrivateKey
+	// TODO: this should not be `kem.PrivateKey`. The encrypting server only needs the target public key!
 	targetPrivate  kem.PrivateKey
 	organizationId string
 	userId         *string


### PR DESCRIPTION
Update `pkg/enclave_encrypt` with the most recent version. This fixes the support for "v1.0.0" bundles: they now contain actual signed bytes rather than JSON structures. This is necessary to ensure signature verification succeeds in 100% of cases. Otherwise we're relying on JSON serialization being consistent (yielding the same exact bytes) between enclaves which produce a signature and clients who verify it.