### PR TITLE
fix MergeMetadata do nothing

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 
 // New returns a new API Client with the given API key name from the default keystore.
 func New(keyname string) (*Client, error) {
-	apiKey, err := local.New[apikey.Key, apikey.Metadata]().Load(keyname)
+	apiKey, err := local.New[*apikey.Key, apikey.Metadata]().Load(keyname)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load API key")
 	}

--- a/examples/apikey/generate.go
+++ b/examples/apikey/generate.go
@@ -31,11 +31,11 @@ func main() {
 		log.Fatalln("failed to generate API key:", err)
 	}
 
-	if err = local.New[apikey.Key, apikey.Metadata]().Store(keyName, key); err != nil {
+	if err = local.New[*apikey.Key, apikey.Metadata]().Store(keyName, key); err != nil {
 		log.Fatalln("failed to store new API key:", err)
 	}
 
-	if key, err = local.New[apikey.Key, apikey.Metadata]().Load(keyName); err != nil {
+	if key, err = local.New[*apikey.Key, apikey.Metadata]().Load(keyName); err != nil {
 		log.Fatalln("failed to load new API key:", err)
 	}
 

--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -220,7 +220,7 @@ func (k Key) LoadMetadata(fn string) (*Metadata, error) {
 }
 
 // MergeMetadata merges the given metadata with the api key.
-func (k Key) MergeMetadata(md Metadata) error {
+func (k *Key) MergeMetadata(md Metadata) error {
 	if k.TkPublicKey != md.PublicKey {
 		return errors.Errorf("metadata public key %q does not match API key public key %q", md.PublicKey, k.TkPublicKey)
 	}

--- a/pkg/apikey/apikey_test.go
+++ b/pkg/apikey/apikey_test.go
@@ -89,3 +89,16 @@ func Test_EncodedKeySizeIsFixed(t *testing.T) {
 		assert.Len(t, apiKey.TkPrivateKey, 64, "attempt %d: expected 64 characters for private key %s", i, apiKey.TkPrivateKey)
 	}
 }
+
+func Test_MetadataMergeWorks(t *testing.T) {
+	k, err := apikey.New(uuid.NewString())
+	assert.Nil(t, err)
+	assert.Equal(t, "", k.GetMetadata().Name)
+
+	err = k.MergeMetadata(apikey.Metadata{
+		Name:      "Custom Name",
+		PublicKey: k.TkPublicKey,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "Custom Name", k.GetMetadata().Name)
+}

--- a/pkg/apikey/apikey_test.go
+++ b/pkg/apikey/apikey_test.go
@@ -92,13 +92,13 @@ func Test_EncodedKeySizeIsFixed(t *testing.T) {
 
 func Test_MetadataMergeWorks(t *testing.T) {
 	k, err := apikey.New(uuid.NewString())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", k.GetMetadata().Name)
 
 	err = k.MergeMetadata(apikey.Metadata{
 		Name:      "Custom Name",
 		PublicKey: k.TkPublicKey,
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Custom Name", k.GetMetadata().Name)
 }

--- a/pkg/encryptionkey/encryptionkey.go
+++ b/pkg/encryptionkey/encryptionkey.go
@@ -202,7 +202,7 @@ func (k Key) LoadMetadata(fn string) (*Metadata, error) {
 }
 
 // MergeMetadata merges the given metadata with the api key.
-func (k Key) MergeMetadata(md Metadata) error {
+func (k *Key) MergeMetadata(md Metadata) error {
 	if k.TkPublicKey != md.PublicKey {
 		return errors.Errorf("metadata public key %q does not match encryption key public key %q", md.PublicKey, k.TkPublicKey)
 	}

--- a/pkg/encryptionkey/encryptionkey_test.go
+++ b/pkg/encryptionkey/encryptionkey_test.go
@@ -19,3 +19,16 @@ func Test_EncodedKeySizeIsFixed(t *testing.T) {
 		assert.Len(t, encryptionKey.TkPrivateKey, 64, "attempt %d: expected 64 characters for private key %s", i, encryptionKey.TkPrivateKey)
 	}
 }
+
+func Test_MetadataMergeWorks(t *testing.T) {
+	k, err := encryptionkey.New(uuid.NewString(), uuid.NewString())
+	assert.Nil(t, err)
+	assert.Equal(t, "", k.GetMetadata().Name)
+
+	err = k.MergeMetadata(encryptionkey.Metadata{
+		Name:      "Custom Name",
+		PublicKey: k.TkPublicKey,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "Custom Name", k.GetMetadata().Name)
+}

--- a/pkg/encryptionkey/encryptionkey_test.go
+++ b/pkg/encryptionkey/encryptionkey_test.go
@@ -22,13 +22,13 @@ func Test_EncodedKeySizeIsFixed(t *testing.T) {
 
 func Test_MetadataMergeWorks(t *testing.T) {
 	k, err := encryptionkey.New(uuid.NewString(), uuid.NewString())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", k.GetMetadata().Name)
 
 	err = k.MergeMetadata(encryptionkey.Metadata{
 		Name:      "Custom Name",
 		PublicKey: k.TkPublicKey,
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Custom Name", k.GetMetadata().Name)
 }

--- a/pkg/store/local/local.go
+++ b/pkg/store/local/local.go
@@ -227,31 +227,31 @@ func (s *Store[T, M]) Store(name string, keypair common.IKey[M]) error {
 }
 
 // Load implements store.Store.
-func (s *Store[T, M]) Load(name string) (*T, error) {
+func (s *Store[T, M]) Load(name string) (T, error) {
 	keyBytes, keyPath, err := s.loadKeyBytes(name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load key bytes %q", name)
+		return *new(T), errors.Wrapf(err, "failed to load key bytes %q", name)
 	}
 
 	kf := store.KeyFactory[T, M]{}
 
 	key, err := kf.FromTurnkeyPrivateKey(string(keyBytes))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to recover key from private key file %q", keyPath)
+		return *new(T), errors.Wrapf(err, "failed to recover key from private key file %q", keyPath)
 	}
 
 	if ok, _ := checkFileExists(s.MetadataFile(name)); ok { //nolint: errcheck
 		metadata, err := key.LoadMetadata(s.MetadataFile(name))
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to load key metadata from metadata file %q", s.MetadataFile(name))
+			return *new(T), errors.Wrapf(err, "failed to load key metadata from metadata file %q", s.MetadataFile(name))
 		}
 
 		if err := key.MergeMetadata(*metadata); err != nil {
-			return nil, errors.Wrap(err, "failed to merge key metadata with key")
+			return *new(T), errors.Wrap(err, "failed to merge key metadata with key")
 		}
 	}
 
-	return &key, nil
+	return key, nil
 }
 
 func (s *Store[T, M]) loadKeyBytes(name string) ([]byte, string, error) {

--- a/pkg/store/local/local_test.go
+++ b/pkg/store/local/local_test.go
@@ -62,7 +62,7 @@ func TestGetAPIKeyDirPathOverride(t *testing.T) {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	}()
 
-	s := local.New[apikey.Key, apikey.Metadata]()
+	s := local.New[*apikey.Key, apikey.Metadata]()
 
 	require.Error(t, s.SetAPIKeysDirectory("/does/not/exist"))
 
@@ -79,7 +79,7 @@ func TestGetEncryptionKeyDirPathOverride(t *testing.T) {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	}()
 
-	s := local.New[encryptionkey.Key, encryptionkey.Metadata]()
+	s := local.New[*encryptionkey.Key, encryptionkey.Metadata]()
 
 	require.Error(t, s.SetEncryptionKeysDirectory("/does/not/exist"))
 

--- a/pkg/store/ram/store.go
+++ b/pkg/store/ram/store.go
@@ -12,35 +12,35 @@ import (
 // Store implements a VOLATILE RAM-based keystore.
 // This should only be used for testing.
 type Store[T common.IKey[M], M common.IMetadata] struct {
-	s map[string]*T
+	s map[string]T
 
 	mu sync.Mutex
 }
 
 // Load implements store.Store.
-func (s *Store[T, M]) Load(name string) (*T, error) {
+func (s *Store[T, M]) Load(name string) (T, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.s == nil {
-		return nil, errors.New("key not found")
+		return *new(T), errors.New("key not found")
 	}
 
 	key, ok := s.s[name]
 	if !ok {
-		return nil, errors.New("key not found")
+		return *new(T), errors.New("key not found")
 	}
 
 	return key, nil
 }
 
 // Store implements store.Store.
-func (s *Store[T, M]) Store(name string, key *T) error {
+func (s *Store[T, M]) Store(name string, key T) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.s == nil {
-		s.s = make(map[string]*T)
+		s.s = make(map[string]T)
 	}
 
 	s.s[name] = key

--- a/pkg/store/ram/store_test.go
+++ b/pkg/store/ram/store_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestApiKeyStore(t *testing.T) {
-	s := new(ram.Store[apikey.Key, apikey.Metadata])
+	s := new(ram.Store[*apikey.Key, apikey.Metadata])
 
 	key, err := apikey.New("2a7e29e2-9e92-48c2-98bf-c849c1159bc7")
 	require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestApiKeyStore(t *testing.T) {
 }
 
 func TestEncryptionKeyStore(t *testing.T) {
-	s := new(ram.Store[encryptionkey.Key, encryptionkey.Metadata])
+	s := new(ram.Store[*encryptionkey.Key, encryptionkey.Metadata])
 
 	key, err := encryptionkey.New("93e79c64-001d-4ee3-8235-590e17bb8068", "2a7e29e2-9e92-48c2-98bf-c849c1159bc7")
 	require.NoError(t, err)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -14,7 +14,7 @@ import (
 // Store provides an interface in which API or Encryption keys may be stored and retrieved.
 type Store[T common.IKey[M], M common.IMetadata] interface {
 	// Load pulls a key from the store.
-	Load(name string) (*T, error)
+	Load(name string) (T, error)
 
 	// Store saves the key to the store.
 	Store(name string, key common.IKey[M]) error
@@ -40,14 +40,14 @@ func (kf KeyFactory[T, M]) FromTurnkeyPrivateKey(data string) (T, error) {
 		}
 		// Since T is an interface, we need to return the concrete type that implements T.
 		// The conversion to T happens automatically if the concrete type satisfies T.
-		return *(interface{}(key).(*T)), nil
+		return (interface{}(key).(T)), nil
 	} else if typeOfT == reflect.TypeOf(encryptionkey.Key{}) {
 		key, err := encryptionkey.FromTurnkeyPrivateKey(data)
 		if err != nil {
 			return instance, err
 		}
 		// Same automatic conversion to T applies here.
-		return *(interface{}(key).(*T)), nil
+		return (interface{}(key).(T)), nil
 	}
 
 	return instance, errors.Errorf("unsupported key type: %v", reflect.TypeOf(instance))


### PR DESCRIPTION
MergeMetadata needs to use a pointer receiver to modify the caller key metadata, use a value receiver won't do anything, 

You can see this happend when running turnkey request command, for example `turnkey request --host api.turnkey.com --path /public/v1/query/list_wallets --body '{"organizationId": "some-org-id"}'`, it will print out

```
{
   "error": "failed to associate the API key with an organization; please manually specify the organization ID"
}
```