### PR TITLE
Removing rogue reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	github.com/cloudflare/circl v1.3.7
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
-	github.com/ethereum/go-ethereum v1.14.5
 	github.com/go-openapi/errors v0.20.4
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
-github.com/ethereum/go-ethereum v1.14.5 h1:szuFzO1MhJmweXjoM5nSAeDvjNUH3vIQoMzzQnfvjpw=
-github.com/ethereum/go-ethereum v1.14.5/go.mod h1:VEDGGhSxY7IEjn98hJRFXl/uFvpRgbIIf2PpXiyGGgc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/apikey/ecdsa.go
+++ b/pkg/apikey/ecdsa.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 
 	dcrec "github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/pkg/errors"
 )
 
@@ -96,7 +95,7 @@ func DecodeTurnkeyPublicECDSAKey(encodedPublicKey string, scheme signatureScheme
 		curve = elliptic.P256()
 		x, y = elliptic.UnmarshalCompressed(curve, bytes)
 	case SchemeSECP256K1:
-		curve = secp256k1.S256()
+		curve = dcrec.S256()
 
 		pubkey, err := dcrec.ParsePubKey(bytes)
 		if err != nil {
@@ -125,7 +124,7 @@ func newECDSAKey(scheme signatureScheme) (*Key, error) {
 	case SchemeP256:
 		curve = elliptic.P256()
 	case SchemeSECP256K1:
-		curve = secp256k1.S256()
+		curve = dcrec.S256()
 	default:
 		// should be unreachable since scheme type is non-exported with discreet options
 		return nil, fmt.Errorf("invalid signature scheme type: %s", scheme)
@@ -161,7 +160,7 @@ func fromTurnkeyECDSAKey(encodedPrivateKey string, scheme signatureScheme) (*Key
 	case SchemeP256:
 		curve = elliptic.P256()
 	case SchemeSECP256K1:
-		curve = secp256k1.S256()
+		curve = dcrec.S256()
 	default:
 		// should be unreachable since scheme type is non-exported with discreet options
 		return nil, fmt.Errorf("invalid signature scheme type: %s", scheme)


### PR DESCRIPTION
Removing rogue go-ethereum package usage and replacing with dcrec so the secp key generation function can be used without CGO.