### PR TITLE
Expose the API error response messages

### DIFF
--- a/client.go
+++ b/client.go
@@ -50,7 +50,9 @@ func (lrt *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 
 			return resp, nil
 		}
+
 		fmt.Printf("Turnkey API response: %s\n", string(body))
+
 		// Rewind the body so it could be re-read
 		resp.Body = io.NopCloser(bytes.NewBuffer(body))
 	}

--- a/client.go
+++ b/client.go
@@ -29,11 +29,11 @@ type config struct {
 // OptionFunc defines a function which sets configuration options for a Client.
 type OptionFunc func(c *config) error
 
-// loggingRoundTripper defines a wrapper around an http.RoundTripper
 type loggingRoundTripper struct {
 	inner http.RoundTripper
 }
 
+// loggingRoundTripper defines a wrapper around an http.RoundTripper.
 func (lrt *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := lrt.inner.RoundTrip(req)
 	if err != nil {
@@ -41,11 +41,11 @@ func (lrt *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 		return nil, err
 	}
 
-	// Log error responses or capture body here
-	if resp.StatusCode >= 400 {
+	// Capture the response body here
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		fmt.Printf("Error response body: %s\n", string(body))
-		// You can re-wrap body if needed
+		fmt.Printf("Turnkey API response: %s\n", string(body))
+		// Rewind the body so it could be re-read
 		resp.Body = io.NopCloser(bytes.NewBuffer(body))
 	}
 

--- a/client.go
+++ b/client.go
@@ -38,12 +38,18 @@ func (lrt *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	resp, err := lrt.inner.RoundTrip(req)
 	if err != nil {
 		fmt.Printf("Request failed: %v\n", err)
+
 		return nil, err
 	}
 
 	// Capture the response body here
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Printf("Failed to read response body: %v\n", err)
+
+			return resp, nil
+		}
 		fmt.Printf("Turnkey API response: %s\n", string(body))
 		// Rewind the body so it could be re-read
 		resp.Body = io.NopCloser(bytes.NewBuffer(body))


### PR DESCRIPTION
Wrap the transport http.RoundTripper so it could throws the API error response body