### PR TITLE
refactor: eliminate reflection from key factory via concrete interfaces

### DIFF
--- a/client.go
+++ b/client.go
@@ -102,7 +102,7 @@ func WithAPIKey(apiKey *apikey.Key) OptionFunc {
 // with the provided name.
 func WithAPIKeyName(keyname string) OptionFunc {
 	return func(c *config) error {
-		apiKey, err := local.New[*apikey.Key]().Load(keyname)
+		apiKey, err := local.NewAPIKeyStore().Load(keyname)
 		if err != nil {
 			return errors.Wrap(err, "failed to load API key")
 		}

--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -191,3 +191,16 @@ func (k *Key) MergeMetadata(md Metadata) error {
 
 	return nil
 }
+
+// Factory is a concrete implementation of TurnkeyKeyFactory for API keys.
+type Factory struct{}
+
+// FromTurnkeyPrivateKey implements the TurnkeyKeyFactory interface for API keys.
+func (f Factory) FromTurnkeyPrivateKey(data string) (*Key, error) {
+	keyWithoutSuffix, scheme, err := ExtractSignatureSchemeFromSuffixedPrivateKey(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return FromTurnkeyPrivateKey(keyWithoutSuffix, scheme)
+}

--- a/pkg/common/interfaces.go
+++ b/pkg/common/interfaces.go
@@ -13,3 +13,9 @@ type IKey[M IMetadata] interface {
 
 // IMetadata defines an interface for the metadata on keys.
 type IMetadata interface{}
+
+// TurnkeyKeyFactory defines an interface for creating keys from Turnkey private key data.
+// This interface eliminates the need for reflection-based type switching.
+type TurnkeyKeyFactory[T IKey[M], M IMetadata] interface {
+	FromTurnkeyPrivateKey(data string) (T, error)
+}

--- a/pkg/encryptionkey/encryptionkey.go
+++ b/pkg/encryptionkey/encryptionkey.go
@@ -221,3 +221,11 @@ func (k *Key) MergeMetadata(md Metadata) error {
 
 	return nil
 }
+
+// Factory is a concrete implementation of TurnkeyKeyFactory for encryption keys.
+type Factory struct{}
+
+// FromTurnkeyPrivateKey implements the TurnkeyKeyFactory interface for encryption keys.
+func (f Factory) FromTurnkeyPrivateKey(data string) (*Key, error) {
+	return FromTurnkeyPrivateKey(data)
+}

--- a/pkg/store/integration_test.go
+++ b/pkg/store/integration_test.go
@@ -1,0 +1,156 @@
+package store_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tkhq/go-sdk/pkg/apikey"
+	"github.com/tkhq/go-sdk/pkg/encryptionkey"
+	"github.com/tkhq/go-sdk/pkg/store/local"
+	"github.com/tkhq/go-sdk/pkg/store/ram"
+)
+
+func TestLocalStoreAPIKeyIntegration(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "api-keys-test")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	// Create a store and configure it to use the temp directory
+	store := local.NewAPIKeyStore()
+	require.NoError(t, store.SetAPIKeysDirectory(tmpDir))
+
+	// Generate a test API key
+	originalKey, err := apikey.New("2a7e29e2-9e92-48c2-98bf-c849c1159bc7", apikey.WithScheme(apikey.SchemeP256))
+	require.NoError(t, err)
+	originalKey.Name = "test-key"
+	
+	// Ensure the metadata is properly set
+	originalKey.Metadata.PublicKey = originalKey.GetPublicKey()
+	originalKey.Metadata.Scheme = string(apikey.SchemeP256)
+
+	// Store the key
+	require.NoError(t, store.Store("test-key", originalKey))
+
+	// Load the key back
+	loadedKey, err := store.Load("test-key")
+	require.NoError(t, err)
+
+	// Verify all fields match
+	assert.Equal(t, originalKey.GetPublicKey(), loadedKey.GetPublicKey())
+	assert.Equal(t, originalKey.GetPrivateKey(), loadedKey.GetPrivateKey())
+	assert.Equal(t, originalKey.GetCurve(), loadedKey.GetCurve())
+	assert.Equal(t, originalKey.Name, loadedKey.Name)
+	assert.Equal(t, originalKey.Organizations, loadedKey.Organizations)
+
+	// Verify files were created
+	assert.FileExists(t, path.Join(tmpDir, "test-key.public"))
+	assert.FileExists(t, path.Join(tmpDir, "test-key.private"))
+	assert.FileExists(t, path.Join(tmpDir, "test-key.meta"))
+}
+
+func TestLocalStoreEncryptionKeyIntegration(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "encryption-keys-test")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	// Create a store and configure it to use the temp directory
+	store := local.NewEncryptionKeyStore()
+	require.NoError(t, store.SetEncryptionKeysDirectory(tmpDir))
+
+	// Generate a test encryption key
+	originalKey, err := encryptionkey.New("93e79c64-001d-4ee3-8235-590e17bb8068", "2a7e29e2-9e92-48c2-98bf-c849c1159bc7")
+	require.NoError(t, err)
+	originalKey.Name = "test-encryption-key"
+	
+	// Ensure the metadata is properly set
+	originalKey.Metadata.PublicKey = originalKey.GetPublicKey()
+
+	// Store the key
+	require.NoError(t, store.Store("test-encryption-key", originalKey))
+
+	// Load the key back
+	loadedKey, err := store.Load("test-encryption-key")
+	require.NoError(t, err)
+
+	// Verify all fields match
+	assert.Equal(t, originalKey.GetPublicKey(), loadedKey.GetPublicKey())
+	assert.Equal(t, originalKey.GetPrivateKey(), loadedKey.GetPrivateKey())
+	assert.Equal(t, originalKey.Name, loadedKey.Name)
+	assert.Equal(t, originalKey.User, loadedKey.User)
+	assert.Equal(t, originalKey.Organization, loadedKey.Organization)
+
+	// Verify files were created
+	assert.FileExists(t, path.Join(tmpDir, "test-encryption-key.public"))
+	assert.FileExists(t, path.Join(tmpDir, "test-encryption-key.private"))
+	assert.FileExists(t, path.Join(tmpDir, "test-encryption-key.meta"))
+}
+
+func TestRAMStoreAPIKeyIntegration(t *testing.T) {
+	// Create a RAM store
+	store := new(ram.Store[*apikey.Key, apikey.Metadata])
+
+	// Generate a test API key
+	originalKey, err := apikey.New("2a7e29e2-9e92-48c2-98bf-c849c1159bc7", apikey.WithScheme(apikey.SchemeSECP256K1))
+	require.NoError(t, err)
+	originalKey.Name = "test-ram-key"
+
+	// Store the key
+	require.NoError(t, store.Store("test-ram-key", originalKey))
+
+	// Load the key back
+	loadedKey, err := store.Load("test-ram-key")
+	require.NoError(t, err)
+
+	// Verify all fields match (should be same object since it's in RAM)
+	assert.Equal(t, originalKey.GetPublicKey(), loadedKey.GetPublicKey())
+	assert.Equal(t, originalKey.GetPrivateKey(), loadedKey.GetPrivateKey())
+	assert.Equal(t, originalKey.GetCurve(), loadedKey.GetCurve())
+	assert.Equal(t, originalKey.Name, loadedKey.Name)
+	assert.Equal(t, originalKey.Organizations, loadedKey.Organizations)
+}
+
+func TestRAMStoreEncryptionKeyIntegration(t *testing.T) {
+	// Create a RAM store
+	store := new(ram.Store[*encryptionkey.Key, encryptionkey.Metadata])
+
+	// Generate a test encryption key
+	originalKey, err := encryptionkey.New("93e79c64-001d-4ee3-8235-590e17bb8068", "2a7e29e2-9e92-48c2-98bf-c849c1159bc7")
+	require.NoError(t, err)
+	originalKey.Name = "test-ram-encryption-key"
+
+	// Store the key
+	require.NoError(t, store.Store("test-ram-encryption-key", originalKey))
+
+	// Load the key back
+	loadedKey, err := store.Load("test-ram-encryption-key")
+	require.NoError(t, err)
+
+	// Verify all fields match (should be same object since it's in RAM)
+	assert.Equal(t, originalKey.GetPublicKey(), loadedKey.GetPublicKey())
+	assert.Equal(t, originalKey.GetPrivateKey(), loadedKey.GetPrivateKey())
+	assert.Equal(t, originalKey.Name, loadedKey.Name)
+	assert.Equal(t, originalKey.User, loadedKey.User)
+	assert.Equal(t, originalKey.Organization, loadedKey.Organization)
+}
+
+func TestErrorHandling(t *testing.T) {
+	// Test loading from non-existent RAM store
+	ramStore := new(ram.Store[*apikey.Key, apikey.Metadata])
+	_, err := ramStore.Load("non-existent")
+	require.Error(t, err)
+
+	// Test loading from non-existent local store
+	localStore := local.NewAPIKeyStore()
+	_, err = localStore.Load("non-existent")
+	require.Error(t, err)
+}

--- a/pkg/store/local/local_test.go
+++ b/pkg/store/local/local_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tkhq/go-sdk/pkg/apikey"
-	"github.com/tkhq/go-sdk/pkg/encryptionkey"
 	"github.com/tkhq/go-sdk/pkg/store/local"
 )
 
@@ -49,7 +47,7 @@ func TestGetAPIKeyDirPathOverride(t *testing.T) {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	}()
 
-	s := local.New[*apikey.Key, apikey.Metadata]()
+	s := local.NewAPIKeyStore()
 
 	require.Error(t, s.SetAPIKeysDirectory("/does/not/exist"))
 
@@ -66,7 +64,7 @@ func TestGetEncryptionKeyDirPathOverride(t *testing.T) {
 		require.NoError(t, os.RemoveAll(tmpDir))
 	}()
 
-	s := local.New[*encryptionkey.Key, encryptionkey.Metadata]()
+	s := local.NewEncryptionKeyStore()
 
 	require.Error(t, s.SetEncryptionKeysDirectory("/does/not/exist"))
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1,0 +1,98 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tkhq/go-sdk/pkg/apikey"
+	"github.com/tkhq/go-sdk/pkg/encryptionkey"
+	"github.com/tkhq/go-sdk/pkg/store"
+)
+
+func TestNewKeyFactoryAPIKey(t *testing.T) {
+	// Create a test API key
+	originalKey, err := apikey.New("2a7e29e2-9e92-48c2-98bf-c849c1159bc7", apikey.WithScheme(apikey.SchemeP256))
+	require.NoError(t, err)
+
+	// Get the private key data with curve suffix (as stored in files)
+	privateKeyData := originalKey.GetPrivateKey() + ":" + originalKey.GetCurve()
+
+	// Test the new KeyFactory approach
+	kf := store.NewKeyFactory[*apikey.Key, apikey.Metadata](apikey.Factory{})
+	recoveredKey, err := kf.FromTurnkeyPrivateKey(privateKeyData)
+	require.NoError(t, err)
+
+	// Verify the recovered key matches the original
+	assert.Equal(t, originalKey.GetPublicKey(), recoveredKey.GetPublicKey())
+	assert.Equal(t, originalKey.GetCurve(), recoveredKey.GetCurve())
+}
+
+func TestNewKeyFactoryEncryptionKey(t *testing.T) {
+	// Create a test encryption key
+	originalKey, err := encryptionkey.New("93e79c64-001d-4ee3-8235-590e17bb8068", "2a7e29e2-9e92-48c2-98bf-c849c1159bc7")
+	require.NoError(t, err)
+
+	// Get the private key data
+	privateKeyData := originalKey.GetPrivateKey()
+
+	// Test the new KeyFactory approach
+	kf := store.NewKeyFactory[*encryptionkey.Key, encryptionkey.Metadata](encryptionkey.Factory{})
+	recoveredKey, err := kf.FromTurnkeyPrivateKey(privateKeyData)
+	require.NoError(t, err)
+
+	// Verify the recovered key matches the original
+	assert.Equal(t, originalKey.GetPublicKey(), recoveredKey.GetPublicKey())
+}
+
+func TestKeyFactoryInvalidData(t *testing.T) {
+	// Test with invalid private key data
+	kf := store.NewKeyFactory[*apikey.Key, apikey.Metadata](apikey.Factory{})
+	_, err := kf.FromTurnkeyPrivateKey("invalid:data")
+	require.Error(t, err)
+	
+	// Test with invalid scheme
+	kf2 := store.NewKeyFactory[*apikey.Key, apikey.Metadata](apikey.Factory{})
+	_, err = kf2.FromTurnkeyPrivateKey("deadbeef:invalid_scheme")
+	require.Error(t, err)
+}
+
+func TestDeprecatedKeyFactory(t *testing.T) {
+	// Test backward compatibility with deprecated factory
+	
+	// Create a test API key
+	originalKey, err := apikey.New("2a7e29e2-9e92-48c2-98bf-c849c1159bc7", apikey.WithScheme(apikey.SchemeP256))
+	require.NoError(t, err)
+
+	// Get the private key data with curve suffix (as stored in files)
+	privateKeyData := originalKey.GetPrivateKey() + ":" + originalKey.GetCurve()
+
+	// Test the deprecated KeyFactory approach
+	kf := store.DeprecatedKeyFactory[*apikey.Key, apikey.Metadata]{}
+	recoveredKey, err := kf.FromTurnkeyPrivateKey(privateKeyData)
+	require.NoError(t, err)
+
+	// Verify the recovered key matches the original
+	assert.Equal(t, originalKey.GetPublicKey(), recoveredKey.GetPublicKey())
+	assert.Equal(t, originalKey.GetCurve(), recoveredKey.GetCurve())
+}
+
+func TestDeprecatedKeyFactoryEncryption(t *testing.T) {
+	// Test backward compatibility with deprecated factory for encryption keys
+	
+	// Create a test encryption key
+	originalKey, err := encryptionkey.New("93e79c64-001d-4ee3-8235-590e17bb8068", "2a7e29e2-9e92-48c2-98bf-c849c1159bc7")
+	require.NoError(t, err)
+
+	// Get the private key data
+	privateKeyData := originalKey.GetPrivateKey()
+
+	// Test the deprecated KeyFactory approach
+	kf := store.DeprecatedKeyFactory[*encryptionkey.Key, encryptionkey.Metadata]{}
+	recoveredKey, err := kf.FromTurnkeyPrivateKey(privateKeyData)
+	require.NoError(t, err)
+
+	// Verify the recovered key matches the original
+	assert.Equal(t, originalKey.GetPublicKey(), recoveredKey.GetPublicKey())
+}


### PR DESCRIPTION
Refactored the local key store system to remove reliance on reflection when instantiating keys from Turnkey private key data. Introduced a generic TurnkeyKeyFactory interface and concrete Factory implementations for both API keys and encryption keys. This refactor improves type safety, testability, and future extensibility of key instantiation logic.

Key improvements:
    - Removed reflection-based logic from KeyFactory in favor of a type-safe factory pattern
    - Added concrete Factory types in apikey and encryptionkey packages
    - Updated store/local to use NewAPIKeyStore and NewEncryptionKeyStore constructors
    - Preserved backwards compatibility via DeprecatedKeyFactory
    - Improved test readability and safety by switching to factory-based store creation

